### PR TITLE
ErrAlreadyExistsInRepo

### DIFF
--- a/src/models/item/item.go
+++ b/src/models/item/item.go
@@ -1,11 +1,17 @@
 package item
 
+import "errors"
+
 type Item interface {
 	Name() string
 	SetName(string)
 	Id() string
 	Species() string
 }
+
+var (
+	ErrAlreadyExistsInRepo = errors.New("Item already exists")
+)
 
 type ItemRepository interface {
 	GetByName(string) (Item, error)


### PR DESCRIPTION
Added ErrAlreadyExistsInRepo to base item struct.  

mysqlSeriesRepository checks if the insert fails because the series already exists and if it does it will fail with ErrAlreadyExistsInRepo.

All Item Repos should fail with this error if the item exists.
